### PR TITLE
Making project clang compilable

### DIFF
--- a/app/examples/dealii_function_test.cpp
+++ b/app/examples/dealii_function_test.cpp
@@ -15,14 +15,14 @@ public:
     {}
 
     virtual double value(const Point <dim> &p,
-            const unsigned int component = 0) const override;
+                         const unsigned int component = 0) const override;
     virtual void vector_value(const Point<dim> &p,
-            Vector<double> & value) const;
+                              Vector<double> & value) const override;
 };
 
 template <int dim>
 double TestFunction<dim>::value(const Point <dim> &p,
-        const unsigned int /*component*/) const
+                                const unsigned int /*component*/) const
 {
     double return_value = 0.0;
     for (unsigned int i = 0; i < dim; ++i)

--- a/app/examples/lebedev_pointer_test.cpp
+++ b/app/examples/lebedev_pointer_test.cpp
@@ -13,7 +13,7 @@ int main()
 
     ld_by_order(order, x, y, z, w);
     ld_by_order(order, &coords[0], &coords[order],
-            &coords[2*order], &coords[3*order]);
+                &coords[2*order], &coords[3*order]);
    
     double sum = 0;
     for (int i=0; i<order; ++i) {
@@ -25,12 +25,12 @@ int main()
 
     std::cout << sum << std::endl;
 
-    delete x;
-    delete y;
-    delete z;
-    delete w;
+    delete[] x;
+    delete[] y;
+    delete[] z;
+    delete[] w;
 
-    delete coords;
+    delete[] coords;
 
     return 0;
 }

--- a/app/examples/plot_uniaxial_nematic.cpp
+++ b/app/examples/plot_uniaxial_nematic.cpp
@@ -55,7 +55,7 @@ template <int dim>
 double UniformConfiguration<dim>::value(const Point<dim> &p,
                                         const unsigned int component) const
 {
-	double return_value{component == 0 ? 1 : 0};
+    double return_value = static_cast<double>(component == 0 ? 1 : 0);
 	return return_value;
 }
 
@@ -223,13 +223,14 @@ public:
 											abs_accuracy, eigenvals,
 											eigenvecs);
 
+      // iterator of maximal eigenvalue
+      auto max_iter = std::max_element(eigenvals.begin(), eigenvals.end());
 			// Find index of maximal eigenvalue
-			unsigned int max_entry{std::distance(eigenvals.begin(),
-												 std::max_element(eigenvals.begin(),
-														          eigenvals.end()))};
-			computed_quantities[p][0] = eigenvecs(0, max_entry);
-			computed_quantities[p][1] = eigenvecs(1, max_entry);
-			if (dim == 3) { computed_quantities[p][2] = eigenvecs(2, max_entry); }
+			auto max_idx = std::distance(eigenvals.begin(), max_iter);
+
+			computed_quantities[p][0] = eigenvecs(0, max_idx);
+			computed_quantities[p][1] = eigenvecs(1, max_idx);
+			if (dim == 3) { computed_quantities[p][2] = eigenvecs(2, max_idx); }
 		}
 
 	}

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,0 +1,147 @@
+[
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/src",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_SERIALIZATION_DYN_LINK -DMaierSaupe_EXPORTS -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -fPIC -std=gnu++14 -o CMakeFiles/MaierSaupe.dir/LUMatrix.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/LUMatrix.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/LUMatrix.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/src",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_SERIALIZATION_DYN_LINK -DMaierSaupe_EXPORTS -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -fPIC -std=gnu++14 -o CMakeFiles/MaierSaupe.dir/LagrangeMultiplier.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/LagrangeMultiplier.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/LagrangeMultiplier.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/src/sphere_lebedev_rule",
+  "command": "/usr/bin/clang++-13 -DSphereLebedevRule_EXPORTS -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule -g -fPIC -std=gnu++14 -o CMakeFiles/SphereLebedevRule.dir/sphere_lebedev_rule.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule/sphere_lebedev_rule.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule/sphere_lebedev_rule.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/src/BoundaryValues",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SERIALIZATION_DYN_LINK -DBoundaryValues_EXPORTS -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/BoundaryValues -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -fPIC -std=gnu++14 -o CMakeFiles/BoundaryValues.dir/UniformConfiguration.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/BoundaryValues/UniformConfiguration.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/BoundaryValues/UniformConfiguration.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/src/BoundaryValues",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SERIALIZATION_DYN_LINK -DBoundaryValues_EXPORTS -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/BoundaryValues -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -fPIC -std=gnu++14 -o CMakeFiles/BoundaryValues.dir/DefectConfiguration.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/BoundaryValues/DefectConfiguration.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/BoundaryValues/DefectConfiguration.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/src/Postprocessors",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_SERIALIZATION_DYN_LINK -DH5_USE_BOOST -DMPI_NO_CPPBIND -DPostprocessors_EXPORTS -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/Postprocessors -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -isystem /usr/include/hdf5/serial -g -fPIC -std=gnu++14 -o CMakeFiles/Postprocessors.dir/EvaluateFEObject.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/Postprocessors/EvaluateFEObject.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/Postprocessors/EvaluateFEObject.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/src/LiquidCrystalSystems",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SERIALIZATION_DYN_LINK -DLiquidCrystalSystems_EXPORTS -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/LiquidCrystalSystems -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -fPIC -std=gnu++14 -o CMakeFiles/LiquidCrystalSystems.dir/IsoSteadyState.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/LiquidCrystalSystems/IsoSteadyState.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/LiquidCrystalSystems/IsoSteadyState.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13   -g -std=gnu++14 -o CMakeFiles/atan_test.dir/atan_test.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/atan_test.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/atan_test.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13   -g -std=gnu++14 -o CMakeFiles/bit_test.dir/bit_test.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/bit_test.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/bit_test.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13  -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/dealii_function_test.dir/dealii_function_test.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/dealii_function_test.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/dealii_function_test.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13  -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/lapack_matrix_test.dir/lapack_matrix_test.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/lapack_matrix_test.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/lapack_matrix_test.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13  -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule -g -std=gnu++14 -o CMakeFiles/lebedev_pointer_test.dir/lebedev_pointer_test.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/lebedev_pointer_test.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/lebedev_pointer_test.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_SERIALIZATION_DYN_LINK -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/lu_matrix_test.dir/lu_matrix_test.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/lu_matrix_test.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/lu_matrix_test.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13  -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/max_element.dir/max_element.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/max_element.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/max_element.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13  -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/plot_gaussian.dir/plot_gaussian.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/plot_gaussian.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/plot_gaussian.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SERIALIZATION_DYN_LINK -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/plot_uniaxial_nematic.dir/plot_uniaxial_nematic.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/plot_uniaxial_nematic.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/plot_uniaxial_nematic.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13  -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/poisson_test.dir/poisson_test.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/poisson_test.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/poisson_test.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SERIALIZATION_DYN_LINK -DH5_USE_BOOST -DMPI_NO_CPPBIND -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -isystem /usr/include/hdf5/serial -g -std=gnu++14 -o CMakeFiles/plot_defect_configuration.dir/plot_defect_configuration.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/plot_defect_configuration.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/plot_defect_configuration.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_SERIALIZATION_DYN_LINK -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/serialize_sparsity_pattern.dir/serialize_sparsity_pattern.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/serialize_sparsity_pattern.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/serialize_sparsity_pattern.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DH5_USE_BOOST -DMPI_NO_CPPBIND -isystem /usr/include/hdf5/serial -g -std=gnu++14 -o CMakeFiles/high_five_example.dir/high_five_example.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/high_five_example.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/high_five_example.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_SERIALIZATION_DYN_LINK -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/serialize_triangulation.dir/serialize_triangulation.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/serialize_triangulation.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/serialize_triangulation.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/examples",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_SERIALIZATION_DYN_LINK -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/serialize_dof_handler.dir/serialize_dof_handler.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/serialize_dof_handler.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/examples/serialize_dof_handler.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/simulations",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SERIALIZATION_DYN_LINK -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/IsoSteadyStateSim.dir/IsoSteadyStateSim.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/simulations/IsoSteadyStateSim.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/simulations/IsoSteadyStateSim.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/app/simulations",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SERIALIZATION_DYN_LINK -DH5_USE_BOOST -DMPI_NO_CPPBIND -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule -isystem /usr/include/hdf5/serial -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/bulk_free_energy_calculation.dir/bulk_free_energy_calculation.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/simulations/bulk_free_energy_calculation.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/app/simulations/bulk_free_energy_calculation.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/test",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_UNIT_TEST_FRAMEWORK_DYN_LINK -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/Factory -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/main_test.dir/main_test.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/test/main_test.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/test/main_test.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/test",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_UNIT_TEST_FRAMEWORK_DYN_LINK -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/Factory -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/main_test.dir/lagrange_multiplier_test.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/test/lagrange_multiplier_test.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/test/lagrange_multiplier_test.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/test",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_UNIT_TEST_FRAMEWORK_DYN_LINK -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/Factory -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/main_test.dir/factory_test.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/test/factory_test.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/test/factory_test.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/test",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_UNIT_TEST_FRAMEWORK_DYN_LINK -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/Factory -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/main_test.dir/boundary_values_test.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/test/boundary_values_test.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/test/boundary_values_test.cpp"
+},
+{
+  "directory": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/build/Debug/test",
+  "command": "/usr/bin/clang++-13 -DBOOST_ALL_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_UNIT_TEST_FRAMEWORK_DYN_LINK -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/sphere_lebedev_rule -I/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/src/Factory -isystem /usr/local/include/deal.II/bundled -isystem /usr/local/cuda-11.4/include -g -std=gnu++14 -o CMakeFiles/main_test.dir/iso_steady_state_test.cpp.o -c /home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/test/iso_steady_state_test.cpp",
+  "file": "/home/lucas/Documents/research/maier-saupe-lc-hydrodynamics/test/iso_steady_state_test.cpp"
+}
+]

--- a/src/maier_saupe_constants.hpp
+++ b/src/maier_saupe_constants.hpp
@@ -5,59 +5,72 @@
 
 namespace maier_saupe_constants{
 
+    template <int space_dim>
+    struct backend {};
+
+    template <>
+    struct backend<2>
+    {
+        // TODO: when everything genuinely works in 2D, uncomment this line
+        static constexpr int vec_dim = 5;
+        static constexpr int mat_dim = 3;
+
+        using vec = std::array<int, vec_dim>;
+        using mat = std::array< std::array<int, mat_dim>, mat_dim>;
+
+        static constexpr vec Q_row = { {0, 0, 1} };
+        static constexpr vec Q_col = { {0, 1, 1} };
+
+        static constexpr mat Q_idx = {{{0, 1, 2}, {1, 3, 4}, {2, 4, 0}}};
+        static constexpr mat delta = {{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}};
+        static constexpr vec delta_vec = { {1, 0, 1} };
+    };
+
+    template <>
+    struct backend<3>
+    {
+        static constexpr int vec_dim = 5;
+        static constexpr int mat_dim = 3;
+
+        using vec = std::array<int, vec_dim>;
+        using mat = std::array< std::array<int, mat_dim>, mat_dim>;
+
+        static constexpr vec Q_row = { {0, 0, 0, 1, 1} };
+        static constexpr vec Q_col = { {0, 1, 2, 1, 2} };
+
+        static constexpr mat Q_idx = {{{0, 1, 2}, {1, 3, 4}, {2, 4, 0}}};
+        static constexpr mat delta = {{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}};
+        static constexpr vec delta_vec = { {1, 0, 0, 1, 0} };
+    };
+
     // dim of (i) vector representing Q-tensor, and (ii) matrix of Q-tensor
     template <int space_dim>
-    constexpr int mat_dim{3};
+    constexpr int vec_dim = backend<space_dim>::vec_dim;
     template <int space_dim>
-    constexpr int vec_dim{};
-
-    // Q-tensor degrees of freedom for 3- and 2-dimensional systems
-    template<>
-    constexpr int vec_dim<3> = 5;
-    // TODO: when everything genuinely works in 2D, uncomment this line
-    // template<>
-    //  constexpr int vec_dim<2> = 3;
-    template<>
-    constexpr int vec_dim<2> = 5;
+    constexpr int mat_dim = backend<space_dim>::mat_dim;
 
     // alias Q-tensor vector and matrix classes
     template <int space_dim>
     using vec = std::array<int, vec_dim<space_dim>>;
     template <int space_dim>
-    using mat = std::array< std::array<int, mat_dim<space_dim>>, 
+    using mat = std::array< std::array<int, mat_dim<space_dim>>,
                             mat_dim<space_dim> >;
 
     // (i, j) indices in Q-tensor given Q-vector index
     template <int space_dim>
-    constexpr vec<space_dim> Q_row = {{}};
+    vec<space_dim> Q_row = backend<space_dim>::Q_row;
     template <int space_dim>
-    constexpr vec<space_dim> Q_col = {{}};
+    vec<space_dim> Q_col = backend<space_dim>::Q_col;
     
-    // explicit indices for 3- and 2-spatial dimensions
-    template <>
-    constexpr vec<3> Q_row<3> = { {0, 0, 0, 1, 1} };
-    template <>
-    constexpr vec<3> Q_col<3> = { {0, 1, 2, 1, 2} };
-    template <>
-    constexpr vec<2> Q_row<2> = { {0, 0, 1} };
-    template <>
-    constexpr vec<2> Q_col<2> = { {0, 1, 1} };
-
     // Q-vector indices given Q-tensor (i, j) indices (except (3, 3) entry)
     template <int space_dim>
-    constexpr mat<space_dim> Q_idx = {{{0, 1, 2}, {1, 3, 4}, {2, 4, 0}}};
-
+    mat<space_dim> Q_idx = backend<space_dim>::Q_idx;
     // Kronecker delta
     template <int space_dim>
-    constexpr mat<space_dim> delta = {{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}};
-
+    mat<space_dim> delta = backend<space_dim>::delta;
     // Vector delta
     template <int space_dim>
-    constexpr vec<space_dim> delta_vec = {{}};
-    template <>
-    constexpr vec<3> delta_vec<3> = { {1, 0, 0, 1, 0} };
-    template <>
-    constexpr vec<2> delta_vec<2> = { {1, 0, 1} };
+    vec<space_dim> delta_vec = backend<space_dim>::delta_vec;
 }
 
 #endif


### PR DESCRIPTION
Fixed bugs to make it clang-compilable so that I could get a working `compile_commands.json` file for use with clangd code parser -- helps with autocomplete, syntax highlighting, goto-definitions, etc.